### PR TITLE
Fixing validation issues and tag injection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nitro-ui"
-version = "1.0.10"
+version = "1.0.11"
 description = "Build HTML with Python, not strings. Zero-dependency library with type-safe elements, method chaining, and JSON serialization."
 readme = "README.md"
 requires-python = ">=3.8"

--- a/src/nitro_ui/core/element.py
+++ b/src/nitro_ui/core/element.py
@@ -823,6 +823,14 @@ class HTMLElement:
 
     @tag.setter
     def tag(self, value: str) -> None:
+        if not value:
+            raise ValueError("A valid HTML tag name is required")
+        if not _VALID_TAG_PATTERN.match(value):
+            raise ValueError(
+                f"Invalid HTML tag name: {value!r}. "
+                "Tag names must start with a letter and contain only "
+                "letters, digits, and hyphens."
+            )
         self._tag = value
 
     @property

--- a/src/nitro_ui/styles/style.py
+++ b/src/nitro_ui/styles/style.py
@@ -1,9 +1,15 @@
 """CSS Style class for NitroUI."""
 
 import copy
+import re
 from typing import Dict, Any
 
 from nitro_ui.core.element import _validate_css_value
+
+# Valid CSS property name: standard ident or a custom property (``--name``).
+# Mirrors the pattern enforced in ``stylesheet.py`` so untrusted dicts can't
+# smuggle at-rules or brace sequences in through property keys.
+_VALID_CSS_PROPERTY_PATTERN = re.compile(r"^(--)?[a-zA-Z][a-zA-Z0-9-]*$")
 
 
 class CSSStyle:
@@ -141,6 +147,12 @@ class CSSStyle:
         if not self._styles:
             return ""
         for key, value in self._styles.items():
+            if not _VALID_CSS_PROPERTY_PATTERN.match(key):
+                raise ValueError(
+                    f"Invalid CSS property name: {key!r}. Property names "
+                    "must be a standard CSS identifier or a custom property "
+                    "starting with '--'."
+                )
             if not _validate_css_value(str(value)):
                 raise ValueError(
                     f"CSS value for '{key}' contains potentially dangerous content: "
@@ -179,9 +191,19 @@ class CSSStyle:
 
         Returns:
             A new ``CSSStyle`` equivalent to the serialized one.
+
+        Raises:
+            ValueError: If any property name in ``data["styles"]`` is not
+                a valid CSS identifier.
         """
         style = cls()
-        style._styles = dict(data.get("styles", {}))
+        raw_styles = dict(data.get("styles", {}))
+        for key in raw_styles:
+            if not _VALID_CSS_PROPERTY_PATTERN.match(key):
+                raise ValueError(
+                    f"Invalid CSS property name in serialized data: {key!r}."
+                )
+        style._styles = raw_styles
 
         if "pseudo" in data:
             for key, value in data["pseudo"].items():

--- a/src/nitro_ui/styles/stylesheet.py
+++ b/src/nitro_ui/styles/stylesheet.py
@@ -14,6 +14,46 @@ if TYPE_CHECKING:
 # followed by letters, digits, underscores, or hyphens
 _VALID_CLASS_NAME_PATTERN = re.compile(r"^-?[_a-zA-Z][_a-zA-Z0-9-]*$")
 
+# Valid CSS property name pattern: a standard ident, or a CSS custom property
+# (``--name``). Blocks at-rules, braces, semicolons, and whitespace from being
+# smuggled in via dict keys (e.g. ``"@import url(evil); color"``).
+_VALID_CSS_PROPERTY_PATTERN = re.compile(r"^(--)?[a-zA-Z][a-zA-Z0-9-]*$")
+
+
+def _validate_css_property(name: str) -> bool:
+    """Validate that a CSS property name is safe for CSS output.
+
+    Args:
+        name: The CSS property name to validate.
+
+    Returns:
+        True if valid, False otherwise.
+    """
+    if not name or not isinstance(name, str):
+        return False
+    return bool(_VALID_CSS_PROPERTY_PATTERN.match(name))
+
+
+def _sanitize_css_property(name: str) -> str:
+    """Return ``name`` if it is a valid CSS property, else raise.
+
+    Args:
+        name: The CSS property name to validate.
+
+    Returns:
+        The property name unchanged.
+
+    Raises:
+        ValueError: If ``name`` is not a valid CSS identifier.
+    """
+    if not _validate_css_property(name):
+        raise ValueError(
+            f"Invalid CSS property name: {name!r}. Property names must be "
+            "a standard CSS identifier (letters, digits, hyphens) or a "
+            "custom property starting with '--'."
+        )
+    return name
+
 
 def _validate_class_name(name: str) -> bool:
     """Validate that a class name is safe for CSS output.
@@ -239,8 +279,9 @@ class StyleSheet:
         if style._styles:
             css_lines.append(f".{class_name} {{")
             for prop, value in style._styles.items():
+                sanitized_prop = _sanitize_css_property(prop)
                 sanitized_value = _sanitize_css_value(value)
-                css_lines.append(f"{indent_str}{prop}: {sanitized_value};")
+                css_lines.append(f"{indent_str}{sanitized_prop}: {sanitized_value};")
             css_lines.append("}")
 
         # Pseudo-selectors
@@ -248,8 +289,11 @@ class StyleSheet:
             if pseudo_style._styles:
                 css_lines.append(f".{class_name}:{pseudo} {{")
                 for prop, value in pseudo_style._styles.items():
+                    sanitized_prop = _sanitize_css_property(prop)
                     sanitized_value = _sanitize_css_value(value)
-                    css_lines.append(f"{indent_str}{prop}: {sanitized_value};")
+                    css_lines.append(
+                        f"{indent_str}{sanitized_prop}: {sanitized_value};"
+                    )
                 css_lines.append("}")
 
         # Responsive breakpoints
@@ -259,9 +303,10 @@ class StyleSheet:
                 css_lines.append(f"@media (min-width: {min_width}) {{")
                 css_lines.append(f"{indent_str}.{class_name} {{")
                 for prop, value in bp_style._styles.items():
+                    sanitized_prop = _sanitize_css_property(prop)
                     sanitized_value = _sanitize_css_value(value)
                     css_lines.append(
-                        f"{indent_str}{indent_str}{prop}: {sanitized_value};"
+                        f"{indent_str}{indent_str}{sanitized_prop}: {sanitized_value};"
                     )
                 css_lines.append(f"{indent_str}}}")
                 css_lines.append("}")

--- a/src/nitro_ui/styles/theme.py
+++ b/src/nitro_ui/styles/theme.py
@@ -1,8 +1,15 @@
 """Theme class for NitroUI styling system."""
 
+import re
 from typing import Dict, Optional, Any
 
+from nitro_ui.core.element import _validate_css_value
 from .style import CSSStyle
+
+# Token names (color/spacing/typography keys) become part of the CSS variable
+# identifier, so they must be safe to splice between ``--<group>-`` and the
+# next character. Letters, digits, underscores, and hyphens only.
+_VALID_TOKEN_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 class Theme:
@@ -54,31 +61,62 @@ class Theme:
         """Flatten colors, spacing, and typography into CSS custom properties.
 
         Called by ``StyleSheet.render()`` when a theme is attached, so
-        every variable lands in the ``:root {}`` block.
+        every variable lands in the ``:root {}`` block. Token names and
+        values are validated to prevent breaking out of the ``:root``
+        declaration via braces, semicolons, or at-rules.
 
         Returns:
             A dict mapping variable names (``--color-primary``,
             ``--spacing-md``, ``--font-body``, ...) to their values.
+
+        Raises:
+            ValueError: If a token name contains characters that aren't
+                safe in a CSS identifier, or a value contains injection
+                patterns (``javascript:``, ``expression()``, braces, etc.).
         """
-        variables = {}
 
-        # Color variables
+        def safe_key(group: str, key: str) -> str:
+            if not isinstance(key, str) or not _VALID_TOKEN_NAME_PATTERN.match(key):
+                raise ValueError(
+                    f"Invalid theme {group} token name: {key!r}. Token names "
+                    "must contain only letters, digits, underscores, or hyphens."
+                )
+            return key
+
+        def safe_value(var_name: str, value: Any) -> str:
+            text = str(value)
+            if not _validate_css_value(text):
+                raise ValueError(
+                    f"Theme variable {var_name!r} contains potentially "
+                    f"dangerous content: {text!r}. Values cannot contain "
+                    "javascript:, expression(), braces, or other injection "
+                    "patterns."
+                )
+            return text
+
+        variables: Dict[str, str] = {}
+
         for key, value in self.colors.items():
-            variables[f"--color-{key}"] = value
+            name = f"--color-{safe_key('color', key)}"
+            variables[name] = safe_value(name, value)
 
-        # Spacing variables
         for key, value in self.spacing.items():
-            variables[f"--spacing-{key}"] = value
+            name = f"--spacing-{safe_key('spacing', key)}"
+            variables[name] = safe_value(name, value)
 
-        # Typography variables
         if isinstance(self.typography, dict):
             for key, value in self.typography.items():
                 if isinstance(value, str):
-                    variables[f"--font-{key}"] = value
+                    name = f"--font-{safe_key('typography', key)}"
+                    variables[name] = safe_value(name, value)
                 elif isinstance(value, dict):
-                    # Handle nested typography settings
+                    group_key = safe_key("typography", key)
                     for sub_key, sub_value in value.items():
-                        variables[f"--font-{key}-{sub_key}"] = str(sub_value)
+                        name = (
+                            f"--font-{group_key}-"
+                            f"{safe_key('typography', sub_key)}"
+                        )
+                        variables[name] = safe_value(name, sub_value)
 
         return variables
 


### PR DESCRIPTION
This pull request introduces stricter validation for HTML tag names, CSS property names, and theme token names/values to prevent injection vulnerabilities and malformed output in NitroUI. The changes add regular expression-based validation and raise clear errors for invalid input throughout the element, style, stylesheet, and theme modules.

**Security and Validation Improvements**

* HTML tag names are now validated in the `tag` setter of `Element`, ensuring they start with a letter and only contain letters, digits, and hyphens.
* CSS property names are validated using a shared regular expression in both `CSSStyle` and the stylesheet renderer, blocking unsafe identifiers and injection vectors. [[1]](diffhunk://#diff-6ec06d7310468e42cadde9c2cd9a398ee31b445394acde4fb0ea200baeabb0c9R4-R13) [[2]](diffhunk://#diff-6ec06d7310468e42cadde9c2cd9a398ee31b445394acde4fb0ea200baeabb0c9R150-R155) [[3]](diffhunk://#diff-6ec06d7310468e42cadde9c2cd9a398ee31b445394acde4fb0ea200baeabb0c9R194-R206) [[4]](diffhunk://#diff-a86782d791879566624f03ddb748abd01dabe958df708bf2cdcae9b4ee25711aR17-R56) [[5]](diffhunk://#diff-a86782d791879566624f03ddb748abd01dabe958df708bf2cdcae9b4ee25711aR282-R296) [[6]](diffhunk://#diff-a86782d791879566624f03ddb748abd01dabe958df708bf2cdcae9b4ee25711aR306-R309)
* Theme token names and values are validated in `Theme.get_css_variables()` to ensure only safe identifiers and values are used for CSS custom properties. [[1]](diffhunk://#diff-c5f9a832532ab177b52988da5c1c623c4126308c712056cf8f35874106bb2882R3-R13) [[2]](diffhunk://#diff-c5f9a832532ab177b52988da5c1c623c4126308c712056cf8f35874106bb2882L57-R119)

**Other Changes**

* The package version is bumped from `1.0.10` to `1.0.11`.